### PR TITLE
Add loading show page

### DIFF
--- a/app/assets/stylesheets/components/_loading.scss
+++ b/app/assets/stylesheets/components/_loading.scss
@@ -1,0 +1,10 @@
+.loading-show {
+    display: flex;
+    justify-content: center;
+    margin-top: 180px;
+    i {
+        font-size: 120px;
+        color: #20EFE3;
+        opacity: 0.6;
+    }
+}

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -4,7 +4,7 @@ $fonts = { "arial" => "'Arial', sans-serif", "verdana" => "'Verdana', sans-serif
 
 class WidgetsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: %i[update preview]
-  before_action :set_widget, only: %i[update edit preview]
+  before_action :set_widget, only: %i[update edit preview show]
 
   def index
     # @fonts = { "arial" => "'Arial', sans-serif", "verdana" => "'Verdana', sans-serif" }
@@ -18,7 +18,7 @@ class WidgetsController < ApplicationController
   end
 
   def show
-    @youtube_data = fetchYoutubeApi("https://www.youtube.com/watch?v=fFgM8mSVjq8")
+    render json: Youtube.where(widget: @widget)
   end
 
   def create

--- a/app/javascript/packs/edit-widget.jsx
+++ b/app/javascript/packs/edit-widget.jsx
@@ -58,7 +58,7 @@ function YoutubePreview(props) {
 function EditWidget() {
     let [previewData, setPreviewData] = useState([]);
     let [display, setDisplay] = useState("forms");
-    let [formData, setFormData] = useState(["", "", ""]);
+    let [formData, setFormData] = useState([""]);
     let [loading, setLoading] = useState(true);
 
     const formUrl = window.location.href.split("/").slice(0, -1).join("/");
@@ -71,11 +71,11 @@ function EditWidget() {
                     .json()
                     .then(res => {
                         let urls = res.map(video => "https://www.youtube.com/watch?v=" + video.video_id )
-                        setFormData(urls);
                         setPreviewData(res);
                         if (urls.length > 0) {
+                            setFormData(urls);
                             setDisplay("preview");
-                        }
+                        }  
                         setLoading(false);
                     });
             })
@@ -167,7 +167,7 @@ function EditWidget() {
                                     { previewData && previewData.map(d => <YoutubePreview youtubeData={d} />) }   
                                 </div>
                                 <div class="submit-dev">
-                                    <input type="button" class="submit-dev-btn-back" value="Back" onClick={()=>{setDisplay("forms")}}/>
+                                    <input type="button" class="submit-dev-btn-back" value="Edit" onClick={()=>{setDisplay("forms")}}/>
                                 </div>                    
                             </div>
                         }  

--- a/app/javascript/packs/edit-widget.jsx
+++ b/app/javascript/packs/edit-widget.jsx
@@ -1,4 +1,4 @@
-import { h, render } from "preact";
+import { h, render, Fragment } from "preact";
 import register from 'preact-custom-element'
 import { useState } from 'preact/hooks'
 
@@ -54,15 +54,17 @@ function YoutubePreview(props) {
     );
 }
 
+
 function EditWidget() {
     let [previewData, setPreviewData] = useState([]);
     let [display, setDisplay] = useState("forms");
     let [formData, setFormData] = useState(["", "", ""]);
-    let [loading, setLoading] = useState(true);
+    let [loading, setLoading] = useState(false);
 
     const formUrl = window.location.href.split("/").slice(0, -1).join("/");
 
     function preview() {
+        setLoading(true);
         const input = document.querySelectorAll('.youtube-link');
         let url = [];
         for (let i of input) {
@@ -81,8 +83,9 @@ function EditWidget() {
             response
                 .json()
                 .then(res => {
-                    setPreviewData(res)
-                    setDisplay("preview")
+                    setPreviewData(res);
+                    setDisplay("preview");
+                    setLoading(false);
                     }
                 );
         })
@@ -147,7 +150,7 @@ function EditWidget() {
                         }  
                     </>
                 }   
-                { 
+                { loading &&
                     <div class="loading-show">
                         <i class="fas fa-spinner fa-pulse"></i>
                     </div>

--- a/app/javascript/packs/edit-widget.jsx
+++ b/app/javascript/packs/edit-widget.jsx
@@ -1,6 +1,6 @@
 import { h, render, Fragment } from "preact";
 import register from 'preact-custom-element'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 
 
 function InputBox(props) {
@@ -59,9 +59,28 @@ function EditWidget() {
     let [previewData, setPreviewData] = useState([]);
     let [display, setDisplay] = useState("forms");
     let [formData, setFormData] = useState(["", "", ""]);
-    let [loading, setLoading] = useState(false);
+    let [loading, setLoading] = useState(true);
 
     const formUrl = window.location.href.split("/").slice(0, -1).join("/");
+
+    function existVideosShow() {
+        setLoading(true);
+        fetch(formUrl)
+        .then(response => {
+            response
+                .json()
+                .then(res => {
+                    let urls = res.map(video => "https://www.youtube.com/watch?v=" + video.video_id )
+                    setFormData(urls);
+                    setLoading(false);
+                });
+        })
+    }
+
+    // Run existVideosShow when this component is created
+    useEffect(() => {
+        existVideosShow();
+    }, []);
 
     function preview() {
         setLoading(true);

--- a/app/javascript/packs/edit-widget.jsx
+++ b/app/javascript/packs/edit-widget.jsx
@@ -66,15 +66,19 @@ function EditWidget() {
     function existVideosShow() {
         setLoading(true);
         fetch(formUrl)
-        .then(response => {
-            response
-                .json()
-                .then(res => {
-                    let urls = res.map(video => "https://www.youtube.com/watch?v=" + video.video_id )
-                    setFormData(urls);
-                    setLoading(false);
-                });
-        })
+            .then(response => {
+                response
+                    .json()
+                    .then(res => {
+                        let urls = res.map(video => "https://www.youtube.com/watch?v=" + video.video_id )
+                        setFormData(urls);
+                        setPreviewData(res);
+                        if (urls.length > 0) {
+                            setDisplay("preview");
+                        }
+                        setLoading(false);
+                    });
+            })
     }
 
     // Run existVideosShow when this component is created

--- a/app/javascript/packs/edit-widget.jsx
+++ b/app/javascript/packs/edit-widget.jsx
@@ -113,7 +113,8 @@ function EditWidget() {
                 </div>
             </div>
             <div class="widget-content-dev">
-                
+                { !loading &&
+                    <>
                         { display==="forms" &&  
                             <form action={formUrl} method="POST">
                                 <div class="content-dev">
@@ -144,7 +145,14 @@ function EditWidget() {
                                 </div>                    
                             </div>
                         }  
-            </div>   
+                    </>
+                }   
+                { 
+                    <div class="loading-show">
+                        <i class="fas fa-spinner fa-pulse"></i>
+                    </div>
+                } 
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
1. Add a loading page to show is loading when clicking the preview button.
2. Loading existing youtube videos and display when going
<img width="1098" alt="Screen Shot 2021-08-14 at 1 43 23" src="https://user-images.githubusercontent.com/47287801/129392199-3b5e0e02-c6d4-40b2-8b05-9070b4139e4d.png">
 to widgets/:id/edit page.
