### PR TITLE
fix show/hide style options

### DIFF
--- a/app/assets/stylesheets/components/_sidebar.scss
+++ b/app/assets/stylesheets/components/_sidebar.scss
@@ -268,12 +268,12 @@
   height: 100%;
   left: 170px;
   transition: all 0.5s ease;
-  // display: none;
+  display: none;
   opacity: 0;
 }
 
 .style-options-wrapper.active {
-  // display: block;
+  display: block;
   opacity: 0.85;
 }
 

--- a/app/assets/stylesheets/components/_sidebar.scss
+++ b/app/assets/stylesheets/components/_sidebar.scss
@@ -267,16 +267,18 @@
   width: 0;
   height: 0;
   left: 170px;
-  transition: opacity 0.5s ease 0.05s;
+  transition: width 0s ease 0.5s, height 0s ease 0.5s, opacity 0.5s ease 0.05s;
   overflow: hidden;
   opacity: 0;
   display: block;
 }
 
+
 .style-options-wrapper.active {
   opacity: 0.85;
   width: 400px;
   height: 100%;
+  transition: opacity 0.5s ease 0.05s;
 }
 
 .sidebar.active ~ .style-options-wrapper {

--- a/app/assets/stylesheets/components/_sidebar.scss
+++ b/app/assets/stylesheets/components/_sidebar.scss
@@ -264,22 +264,22 @@
 .style-options-wrapper {
   position: absolute;
   padding: 130px 0;
-  width: 400px;
-  height: 100%;
+  width: 0;
+  height: 0;
   left: 170px;
-  transition: all 0.5s ease;
-  display: none;
+  transition: opacity 0.5s ease 0.05s;
+  overflow: hidden;
   opacity: 0;
+  display: block;
 }
 
 .style-options-wrapper.active {
-  display: block;
   opacity: 0.85;
+  width: 400px;
+  height: 100%;
 }
 
 .sidebar.active ~ .style-options-wrapper {
-  width: 400px;
-  height: 100%;
   left: 330px;
 }
 

--- a/app/assets/stylesheets/components/_sidebar.scss
+++ b/app/assets/stylesheets/components/_sidebar.scss
@@ -267,7 +267,7 @@
   width: 0;
   height: 0;
   left: 170px;
-  transition: width 0s ease 0.5s, height 0s ease 0.5s, opacity 0.5s ease 0.05s;
+  transition: width 0s ease 0.5s, height 0s ease 0.5s, opacity 0.5s ease;
   overflow: hidden;
   opacity: 0;
   display: block;


### PR DESCRIPTION
Make the invisible style options div `display: none`, because the invisible div was stopping me from clicking the buttons on the widget.
<img width="719" alt="Screen Shot 2021-08-15 at 17 27 27" src="https://user-images.githubusercontent.com/47287801/129472180-31bb3cb1-bbdd-4280-b19e-851a02901a07.png">
