### PR TITLE
Fix z-index issues with sidebar and widget

### DIFF
--- a/app/assets/stylesheets/widgets/_list.scss
+++ b/app/assets/stylesheets/widgets/_list.scss
@@ -12,6 +12,7 @@
 .left-column-sidebar {
   height: 100%;
   display: flex;
+  z-index: 10;
 }
 
 .right-column-content {


### PR DESCRIPTION
Before:
<img width="753" alt="Screen Shot 2021-08-15 at 17 32 56" src="https://user-images.githubusercontent.com/47287801/129472315-739b1cd0-ae76-4e39-ac94-33a0cc0fc5a0.png">

After:
<img width="749" alt="Screen Shot 2021-08-15 at 17 32 43" src="https://user-images.githubusercontent.com/47287801/129472317-5f4a7a42-a830-47e0-85dd-c48ab95e62bb.png">
