### PR TITLE
Fix border radius on style options background div

### DIFF
--- a/app/assets/stylesheets/components/_sidebar.scss
+++ b/app/assets/stylesheets/components/_sidebar.scss
@@ -535,6 +535,7 @@
 
 .style-options-content.background.active {
   display: block;
+  border-radius: 12px;
 }
 
 .colorPicker {


### PR DESCRIPTION
I don't know why this is needed, but without it there is no border radius on the background style options div.
<img width="370" alt="Screen Shot 2021-08-15 at 18 20 04" src="https://user-images.githubusercontent.com/47287801/129473658-438e99e4-d4d0-4393-a011-88946af7dc81.png">
<img width="405" alt="Screen Shot 2021-08-15 at 18 19 51" src="https://user-images.githubusercontent.com/47287801/129473661-5bd84637-07e4-4641-8278-bf949d2624b8.png">
