### PR TITLE
adjust scrollbar width

### DIFF
--- a/app/assets/stylesheets/widgets/_edit.scss
+++ b/app/assets/stylesheets/widgets/_edit.scss
@@ -1,21 +1,21 @@
-*::-webkit-scrollbar-track
+.content-dev::-webkit-scrollbar-track
 {
   -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
   box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
-  border-radius: 8px;
+  border-radius: 5px;
   background-color: lightgray;
 }
 
-*::-webkit-scrollbar
+.content-dev::-webkit-scrollbar
 {
-  width: 12px;
+  width: 5px;
   background-color: lightgray;
-  border-radius: 8px;
+  border-radius: 3px;
 }
 
-*::-webkit-scrollbar-thumb
+.content-dev::-webkit-scrollbar-thumb
 {
-  border-radius: 8px;
+  border-radius: 3px;
   -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,.3);
   box-shadow: inset 0 0 6px rgba(0,0,0,.3);
   background-color: #EAEEF3;


### PR DESCRIPTION
1. Adjust scrollbar width to match the topbar highlight width a little bit. 
2. It was affecting the user's webpage scrollbar too before. I think is better to let the scrollbar only affect our widget.

After: 
<img width="1439" alt="Screen Shot 2021-08-27 at 3 52 43" src="https://user-images.githubusercontent.com/47287801/131019858-63f51f49-2c00-4e22-ad36-37ca4405be15.png">
Before:
<img width="1440" alt="Screen Shot 2021-08-27 at 3 52 59" src="https://user-images.githubusercontent.com/47287801/131019848-879904d7-7236-478a-8a4d-27a7b72bea31.png">