### PR TITLE
update seeds to show bad performing widget

### DIFF
--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -95,6 +95,13 @@ class WidgetsController < ApplicationController
       @widget_sessions = @user_widget.first.widget_accesses.count
       @widget_clicks = @user_widget.first.content_accesses.count
       @widget_time = seconds_to_units(widget_time(@user_widget.first))
+      @content_accesses_per_day = @user_widget.first.content_accesses.group_by_day(:click_at, last: 7, current: false).count
+      @widget_sessions_per_day = @user_widget.first.widget_accesses.group_by_day(:open_at, last: 7, current: false).count
+      @widget_session_time_per_day = @user_widget.first.widget_accesses.group_by_day(:open_at, last: 7, current: false).sum(:session_time)
+    else
+      @content_accesses_per_day = ContentAccess.group_by_day(:click_at, last: 7, current: false).count
+      @widget_sessions_per_day = WidgetAccess.group_by_day(:open_at, last: 7, current: false).count
+      @widget_session_time_per_day = WidgetAccess.group_by_day(:open_at, last: 7, current: false).sum(:session_time)
     end
 
     @global_sessions = global_sessions(@user_widgets)

--- a/app/views/shared/_widget_stats.html.erb
+++ b/app/views/shared/_widget_stats.html.erb
@@ -5,7 +5,7 @@
       <h4><%= @widget_time %></h4>
     </div>
     <div class="session-time-chart">
-      <%= column_chart WidgetAccess.group_by_day(:open_at).sum(:session_time), ytitle: "Time per day" %>
+      <%= column_chart @widget_session_time_per_day, ytitle: "Time per day" %>
     </div>
   </div>
   <div class="total-session-time-wrapper">
@@ -14,7 +14,7 @@
       <h4><%= @widget_sessions %> sessions</h4>
     </div>
     <div class="session-time-chart">
-      <%= area_chart WidgetAccess.group_by_day(:open_at).count, ytitle: "Number of Sessions"%>
+      <%= area_chart @widget_sessions_per_day, ytitle: "Number of Sessions", series: true %>
     </div>
   </div>
   <div class="total-clicks-wrapper">
@@ -23,7 +23,7 @@
       <h4><%= @widget_clicks %> clicks</h4>
     </div>
     <div class="clicks-chart">
-      <%= area_chart ContentAccess.group_by_day(:click_at).count, ytitle: "Number of Clicks" %>
+      <%= area_chart @content_accesses_per_day, ytitle: "Number of Clicks" %>
     </div>
   </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -258,7 +258,7 @@ end
 puts "*----------------------------------"
 
 puts "creating widget accesses widget1"
-43.times do
+430.times do
   start_at = Faker::Time.between_dates(from: Date.today - 7, to: Date.today, period: :all)
   close_at = start_at + rand(5..120).seconds
   session_time = close_at.to_i - start_at.to_i
@@ -266,15 +266,22 @@ puts "creating widget accesses widget1"
 end
 
 puts "creating widget accesses widget2"
-19.times do
-  start_at = Faker::Time.between_dates(from: Date.today - 7, to: Date.today, period: :all)
-  close_at = start_at + rand(5..120).seconds
+100.times do
+  start_at = Faker::Time.between_dates(from: Date.today - 7, to: Date.today - 3, period: :all)
+  close_at = start_at + rand(20..120).seconds
+  session_time = close_at.to_i - start_at.to_i
+  WidgetAccess.create(open_at: start_at, close_at: close_at, session_time: session_time, widget_id: Widget.all[1].id)
+end
+
+60.times do
+  start_at = Faker::Time.between_dates(from: Date.today - 3, to: Date.today, period: :all)
+  close_at = start_at + rand(5..10).seconds
   session_time = close_at.to_i - start_at.to_i
   WidgetAccess.create(open_at: start_at, close_at: close_at, session_time: session_time, widget_id: Widget.all[1].id)
 end
 
 puts "creating widget accesses widget3"
-28.times do
+280.times do
   start_at = Faker::Time.between_dates(from: Date.today - 7, to: Date.today, period: :all)
   close_at = start_at + rand(5..120).seconds
   session_time = close_at.to_i - start_at.to_i
@@ -282,7 +289,7 @@ puts "creating widget accesses widget3"
 end
 
 puts "creating widget accesses widget4"
-60.times do
+600.times do
   start_at = Faker::Time.between_dates(from: Date.today - 7, to: Date.today, period: :all)
   close_at = start_at + rand(5..120).seconds
   session_time = close_at.to_i - start_at.to_i
@@ -290,7 +297,7 @@ puts "creating widget accesses widget4"
 end
 
 puts "creating widget accesses widget5"
-47.times do
+470.times do
   start_at = Faker::Time.between_dates(from: Date.today - 7, to: Date.today, period: :all)
   close_at = start_at + rand(5..120).seconds
   session_time = close_at.to_i - start_at.to_i
@@ -300,65 +307,77 @@ end
 puts "*----------------------------------"
 
 puts "creating content accesses widget1"
-20.times do
+200.times do
   random_youtube = Youtube.where(widget_id: Widget.first.id).sample
   click_at = Faker::Date.between(from: 7.days.ago, to: Date.today)
   ContentAccess.create(click_at: click_at, source: "Youtube", source_id: random_youtube.id, widget_id: Widget.first.id)
 end
 
-23.times do
+230.times do
   random_reddit = Reddit.where(widget_id: Widget.first.id).sample
   click_at = Faker::Date.between(from: 7.days.ago, to: Date.today)
   ContentAccess.create(click_at: click_at, source: "Reddit", source_id: random_reddit.id, widget_id: Widget.first.id)
 end
 
 puts "creating content accesses widget2"
-4.times do
+20.times do
   random_youtube = Youtube.where(widget_id: Widget.all[1].id).sample
-  click_at = Faker::Date.between(from: 7.days.ago, to: Date.today)
+  click_at = Faker::Date.between(from: 4.days.ago, to: Date.today)
   ContentAccess.create(click_at: click_at, source: "Youtube", source_id: random_youtube.id, widget_id: Widget.all[1].id)
 end
 
-8.times do
+120.times do
+  random_youtube = Youtube.where(widget_id: Widget.all[1].id).sample
+  click_at = Faker::Date.between(from: 8.days.ago, to: 4.days.ago)
+  ContentAccess.create(click_at: click_at, source: "Youtube", source_id: random_youtube.id, widget_id: Widget.all[1].id)
+end
+
+20.times do
   random_reddit = Reddit.where(widget_id: Widget.all[1].id).sample
-  click_at = Faker::Date.between(from: 7.days.ago, to: Date.today)
+  click_at = Faker::Date.between(from: 4.days.ago, to: Date.today)
+  ContentAccess.create(click_at: click_at, source: "Reddit", source_id: random_reddit.id, widget_id: Widget.all[1].id)
+end
+
+120.times do
+  random_reddit = Reddit.where(widget_id: Widget.all[1].id).sample
+  click_at = Faker::Date.between(from: 8.days.ago, to: 4.days.ago)
   ContentAccess.create(click_at: click_at, source: "Reddit", source_id: random_reddit.id, widget_id: Widget.all[1].id)
 end
 
 puts "creating content accesses widget3"
-30.times do
+300.times do
   random_youtube = Youtube.where(widget_id: Widget.all[2].id).sample
   click_at = Faker::Date.between(from: 7.days.ago, to: Date.today)
   ContentAccess.create(click_at: click_at, source: "Youtube", source_id: random_youtube.id, widget_id: Widget.all[2].id)
 end
 
-28.times do
+280.times do
   random_reddit = Reddit.where(widget_id: Widget.all[2].id).sample
   click_at = Faker::Date.between(from: 7.days.ago, to: Date.today)
   ContentAccess.create(click_at: click_at, source: "Reddit", source_id: random_reddit.id, widget_id: Widget.all[2].id)
 end
 
 puts "creating content accesses widget4"
-45.times do
+450.times do
   random_youtube = Youtube.where(widget_id: Widget.all[3].id).sample
   click_at = Faker::Date.between(from: 7.days.ago, to: Date.today)
   ContentAccess.create(click_at: click_at, source: "Youtube", source_id: random_youtube.id, widget_id: Widget.all[3].id)
 end
 
-50.times do
+500.times do
   random_reddit = Reddit.where(widget_id: Widget.all[3].id).sample
   click_at = Faker::Date.between(from: 7.days.ago, to: Date.today)
   ContentAccess.create(click_at: click_at, source: "Reddit", source_id: random_reddit.id, widget_id: Widget.all[3].id)
 end
 
 puts "creating content accesses widget5"
-39.times do
+390.times do
   random_youtube = Youtube.where(widget_id: Widget.all[1].id).sample
   click_at = Faker::Date.between(from: 7.days.ago, to: Date.today)
   ContentAccess.create(click_at: click_at, source: "Youtube", source_id: random_youtube.id, widget_id: Widget.all[4].id)
 end
 
-31.times do
+310.times do
   random_reddit = Reddit.where(widget_id: Widget.all[1].id).sample
   click_at = Faker::Date.between(from: 7.days.ago, to: Date.today)
   ContentAccess.create(click_at: click_at, source: "Reddit", source_id: random_reddit.id, widget_id: Widget.all[4].id)


### PR DESCRIPTION
1. Show performance get worse for A20 Aviation Headset
2. Make all seeds have 10x more data, because graphs were too random
3. Make graphs show data for just one widget if a widget is selected


With the bad performing widget, the number of sessions is the same but clicks and session time drops, as if people arent interested in the links and just closing the widget.

![screencapture-127-0-0-1-3000-analytics-2021-08-28-14_21_25](https://user-images.githubusercontent.com/47287801/131207235-b3f204c7-3b61-4f6b-803c-024b5668de42.png)
