### PR TITLE
fixed nav-btn highlight on wrong nav-btn

### DIFF
--- a/app/javascript/components/sidebar.js
+++ b/app/javascript/components/sidebar.js
@@ -19,10 +19,10 @@ const sideBar = () => {
   const fontSizeValue = document.getElementById("font-size-value");
 
   const initialState = () => {
-    if (window.location.pathname === "/widgets") {
-      navBtns[0].classList.add("focus")
-    } else {
+    if (window.location.pathname === "/analytics") {
       navBtns[2].classList.add("focus")
+    } else {
+      navBtns[0].classList.add("focus")
     }
   }
 


### PR DESCRIPTION
With this pr, when you click on the specific project, the sidebar highlight will stay in the products button, won't jump to analytics button anymore.